### PR TITLE
feat: Add Launch at Login toggle

### DIFF
--- a/Celluloid/ContentView.swift
+++ b/Celluloid/ContentView.swift
@@ -6,10 +6,12 @@
 //
 
 import SwiftUI
+import ServiceManagement
 
 struct ContentView: View {
     @EnvironmentObject var cameraManager: CameraManager
     @ObservedObject var extensionManager = ExtensionManager.shared
+    @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
 
     var body: some View {
         VStack(spacing: 0) {
@@ -119,6 +121,23 @@ struct ContentView: View {
                         Label("Reset All", systemImage: "arrow.counterclockwise")
                     }
                     .buttonStyle(.bordered)
+
+                    Spacer()
+
+                    Toggle("Launch at Login", isOn: $launchAtLogin)
+                        .toggleStyle(.checkbox)
+                        .font(.caption)
+                        .onChange(of: launchAtLogin) { _, newValue in
+                            do {
+                                if newValue {
+                                    try SMAppService.mainApp.register()
+                                } else {
+                                    try SMAppService.mainApp.unregister()
+                                }
+                            } catch {
+                                launchAtLogin = !newValue
+                            }
+                        }
 
                     Spacer()
 


### PR DESCRIPTION
## Summary

- Adds a "Launch at Login" checkbox to the bottom controls bar
- Uses `SMAppService.mainApp` from the `ServiceManagement` framework
- No additional entitlements needed — works with the existing sandbox configuration
- Users can also manage this via System Settings > General > Login Items

Closes #25 if applicable.

## Test plan

- [ ] Toggle on, reboot, verify Celluloid launches automatically
- [ ] Toggle off, reboot, verify it does not launch
- [ ] Verify the checkbox reflects the current state on app launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)